### PR TITLE
Fix version conflicts caused by PR#28

### DIFF
--- a/Arke.ServiceHost/Arke.ServiceHost.csproj
+++ b/Arke.ServiceHost/Arke.ServiceHost.csproj
@@ -10,12 +10,12 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc.Core" Version="5.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="SimpleInjector" Version="5.3.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="6.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.1.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="6.1.5" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="Arke.ARI" Version="1.3.0" />
   </ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Swashbuckle.AspNetCore.SwaggerGen from 6.1.4 to 6.1.5. [(PR#28)](https://github.com/quasarke/arke/pull/28).
Hope this fix can help you.

Best regards,
sucrose